### PR TITLE
Renaming start index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ usage: IncrementalMavenCrawler
                                   hours). Defaults to 1 hour.
  -o,--output <[std|kafka|rest]>   Output to send the crawled artifacts to.
                                   Defaults to std.
+ -si,start_index                  Index to start crawling from (inclusive). Required.
  -bs,--batch_size <amount>        Size of batches to send to output.
                                   Defaults to 50.
  -cd,--checkpoint_dir <hours>     Directory to checkpoint/store latest

--- a/src/main/java/eu/fasten/crawler/IncrementalMavenCrawler.java
+++ b/src/main/java/eu/fasten/crawler/IncrementalMavenCrawler.java
@@ -18,7 +18,7 @@ public class IncrementalMavenCrawler implements Runnable {
 
     // Arguments for incremental maven crawler.
     static Options options = new Options();
-    static Option optStartIndex = Option.builder("i")
+    static Option optStartIndex = Option.builder("si")
             .longOpt("start_index")
             .hasArg()
             .argName("index")

--- a/src/test/java/eu/fasten/crawler/IncrementalMavenCrawlerTest.java
+++ b/src/test/java/eu/fasten/crawler/IncrementalMavenCrawlerTest.java
@@ -1,12 +1,13 @@
 package eu.fasten.crawler;
 
 import eu.fasten.crawler.output.StdOutput;
+import org.apache.commons.cli.Option;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.Int;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyList;
@@ -145,7 +146,7 @@ public class IncrementalMavenCrawlerTest {
         verify(stdOutput, atLeastOnce()).send(anyList());
         assertEquals(index + 1, crawler.getIndex());
 
-        new File("src/test/resources/" + (index + 1)  + ".index").delete();
+        new File("src/test/resources/" + (index + 1) + ".index").delete();
     }
 
     @Test
@@ -160,5 +161,23 @@ public class IncrementalMavenCrawlerTest {
 
         verify(stdOutput, atLeastOnce()).send(anyList());
         assertEquals(index, crawler.getIndex());
+    }
+
+    /**
+     * This test aims to detect multiple options with same name.
+     * It compares number of Option static attribute declared in IncrementalMavenCrawler with
+     * number of elements in the list provided by Options.getOptions().
+     */
+    @Test
+    public void testAddOptions() {
+        // Count number of Option static attribute declared in IncrementalMavenCrawler
+        long numberOfOptionsDelcared = Arrays.stream(IncrementalMavenCrawler.class.getDeclaredFields()).filter(field -> field.getType() == Option.class).count();
+
+        IncrementalMavenCrawler.addOptions();
+
+        // Number of options registered in options attribute (Apache CLI Options class)
+        long actualNumberOfOptions = IncrementalMavenCrawler.options.getOptions().size();
+
+        assertEquals(numberOfOptionsDelcared, actualNumberOfOptions);
     }
 }


### PR DESCRIPTION
Start index option short name was "i" leading to a conflict with interval option also named "i".
Apache CLI library tolerate multiple options with same short name but actually only kept one. Change include a test that compare options declared with options count reported by Apache CLI.
Option start index short name is now -si.

This should close #3.